### PR TITLE
Allows building with clang and fixes user-after-free

### DIFF
--- a/FL/Fl_Widget.H
+++ b/FL/Fl_Widget.H
@@ -110,6 +110,7 @@ struct FL_EXPORT Fl_Label {
  */
 class FL_EXPORT Fl_Widget {
   friend class Fl_Group;
+  friend class Fl_X;
 
   Fl_Group* parent_;
   Fl_Callback* callback_;

--- a/fluid/Fl_Type.h
+++ b/fluid/Fl_Type.h
@@ -45,7 +45,6 @@ void set_modflag(int mf);
 class Fl_Type {
 
   friend class Widget_Browser;
-  friend Fl_Widget *make_type_browser(int,int,int,int,const char *l=0);
   friend class Fl_Window_Type;
   virtual void setlabel(const char *); // virtual part of label(char*)
 

--- a/src/Fl_Widget.cxx
+++ b/src/Fl_Widget.cxx
@@ -282,10 +282,10 @@ Fl_Widget::label(const char *a) {
 
 void
 Fl_Widget::copy_label(const char *a) {
-  if (flags() & COPIED_LABEL) free((void *)(label_.value));
-
   if ( ( !a || !label_.value ) || strcmp( a, label_.value ) )
       redraw_label();
+
+  if (flags() & COPIED_LABEL) free((void *)(label_.value));
 
   if (a) {
     set_flag(COPIED_LABEL);
@@ -294,6 +294,7 @@ Fl_Widget::copy_label(const char *a) {
     clear_flag(COPIED_LABEL);
     label_.value=(char *)0;
   }
+
 }
 
 /** Calls the widget callback.


### PR DESCRIPTION
Some minor changes to allow building with clang (4.0). This PR also fixes a user-after-free when setting labels on widgets. 